### PR TITLE
Fix (ci): Revert `release-drafter.yml` back to default template and use pushed tag directly for published release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$RESOLVED_VERSION  🌈'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION  🌈'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -284,5 +284,7 @@ jobs:
         with:
           # config-name: release-drafter.yaml
           publish: true
+          name: ${{  github.ref_name }}
+          tag: ${{  github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts #23